### PR TITLE
ci: run migrations when deploying to stage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,6 +191,11 @@ jobs:
       - aws-cli/configure
 
       - run:
+          name: Migrate database
+          command: |
+            node scripts/ecs_db_migrate.rb
+
+      - run:
           name: Deploy new task in ECS
           command: |
             aws ecs update-service --cluster $ECS_CLUSTER --service $ECS_SERVICE --force-new-deployment

--- a/scripts/ecs_db_migrate.js
+++ b/scripts/ecs_db_migrate.js
@@ -1,0 +1,38 @@
+#! /usr/bin/env node
+/*eslint no-console: 0*/
+const { exec } = require("child_process");
+const cluster = process.env.ECS_CLUSTER;
+const service = process.env.ECS_SERVICE;
+const taskDefinition = `${service}_${cluster}`;
+
+if (!cluster || !service) {
+	process.exit(
+		"Both ECS_CLUSTER and ECS_SERVICE env variables need to be present."
+	);
+}
+
+const overrides = {
+	containerOverrides: [
+		{
+			name: service,
+			memoryReservation: 64,
+			command: ["yarn", "db:migrate"]
+		}
+	]
+};
+
+const migrationCommand = `aws ecs run-task --started-by db-migrate --cluster ${cluster} --task-definition ${taskDefinition} --overrides '${JSON.stringify(
+	overrides
+)}'`;
+
+console.log(migrationCommand);
+
+(async function() {
+	try {
+		await exec(migrationCommand);
+	} catch (e) {
+		console.log(e);
+	} finally {
+		process.exit();
+	}
+})();


### PR DESCRIPTION
**What:** Run migrations when deploying to stage

**Why:** To have the database updated on every deployment

**How:**

- Create a script that executes a ECS command to deploy a one-off task 