### PR TITLE
add "getUserActions" resolver from UserActions

### DIFF
--- a/models/Action.js
+++ b/models/Action.js
@@ -42,6 +42,7 @@ class Action extends Model {
           to: 'users.id'
         }
       }
+      // TODO: we need to address issue #20
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "db:drop": "node scripts/db/dropdb.js",
     "db:migrate": "knex migrate:latest",
     "db:seed": "knex seed:run",
+    "db:dev:prepare": "cross-env-shell \"yarn db:drop && yarn db:create && yarn db:migrate && yarn db:seed\"",
     "db:test:prepare": "cross-env-shell NODE_ENV=test \"yarn db:drop && yarn db:create && yarn db:migrate\"",
     "start": "node index.js",
     "dev": "nodemon index.js",

--- a/resolvers/UserActions.js
+++ b/resolvers/UserActions.js
@@ -92,7 +92,7 @@ const Query = {
       }
     })
 
-    return result
+    return _.sortBy(result, 'actionId')
   }
 }
 

--- a/resolvers/UserActions.js
+++ b/resolvers/UserActions.js
@@ -74,6 +74,7 @@ const Query = {
       .where('campaignId', context.Campaign.id)
     const userActions = userQuery ? userQuery.userActions : []
 
+    // TODO: we need to address issue #20
     const result = actions.map(action => {
       const userActionByActionId = _.defaultTo(
         _.find(userActions, {

--- a/resolvers/UserActions.js
+++ b/resolvers/UserActions.js
@@ -72,20 +72,23 @@ const Query = {
       .findById(userId)
       .joinEager('userActions')
       .where('campaignId', context.Campaign.id)
-
-    if (!userQuery) {
-      return actions
-    }
+    const userActions = userQuery ? userQuery.userActions : []
 
     const result = actions.map(action => {
       const userActionByActionId = _.defaultTo(
-        _.find(userQuery.userActions, {
+        _.find(userActions, {
           actionId: action.id
         }),
         { completed: false }
       )
+      const actionData = _.omit(action, ['id'])
 
-      return { ...action, completed: userActionByActionId.completed }
+      return {
+        ...actionData,
+        actionId: action.id,
+        userActionId: userActionByActionId.id,
+        completed: userActionByActionId.completed
+      }
     })
 
     return result

--- a/resolvers/__tests__/UserActions.spec.js
+++ b/resolvers/__tests__/UserActions.spec.js
@@ -242,4 +242,22 @@ describe('getUserActions query', () => {
 
     expect(result[0].completed).toBeTruthy()
   })
+
+  it('returns a reference to the userActionId and actionId', async () => {
+    const context = { User: stubs.currentUser, Campaign: stubs.currentCampaign }
+    const userId = stubs.currentUser.id
+    const firstAction = await Action.query().first()
+
+    // create a UserAction using `actions[0].id`
+    const userAction = await UserAction.query().insert({
+      actionId: stubs.actions[0].id,
+      campaignId: stubs.currentCampaign.id,
+      userId: stubs.currentUser.id
+    })
+
+    const result = await Query.getUserActions(null, { userId }, context)
+
+    expect(result[0].userActionId).toEqual(userAction.id)
+    expect(result[0].actionId).toEqual(firstAction.id)
+  })
 })

--- a/resolvers/__tests__/UserActions.spec.js
+++ b/resolvers/__tests__/UserActions.spec.js
@@ -3,7 +3,11 @@ const { Action } = require('../../models/Action')
 const { Campaign } = require('../../models/Campaign')
 const { User } = require('../../models/User')
 const { UserAction } = require('../../models/UserAction')
-const { Mutation } = require('../UserActions')
+const { Mutation, Query } = require('../UserActions')
+const faker = require('faker')
+const _ = require('lodash')
+
+afterAll(() => Model.knex().destroy())
 
 describe('UserActions resolvers', () => {
   describe('createDataDues', () => {
@@ -11,8 +15,6 @@ describe('UserActions resolvers', () => {
     let campaign
     let context
     let action
-
-    afterAll(() => Model.knex().destroy())
 
     beforeEach(async () => {
       await UserAction.query().delete()
@@ -154,5 +156,90 @@ describe('UserActions resolvers', () => {
         })
       })
     })
+  })
+})
+
+describe('getUserActions query', () => {
+  const stubs = {
+    currentUser: null,
+    currentCampaign: null,
+    actions: []
+  }
+
+  beforeEach(async () => {
+    // Clean the database
+    await UserAction.query().delete()
+    await Action.query().delete()
+    await User.query().delete()
+    await Campaign.query().delete()
+
+    // Create a base campaign to work with
+    const campaign = await Campaign.query().insert({
+      slug: 'end-student-debt',
+      name: 'End Student Debt'
+    })
+
+    // Create actions
+    const actions = Array(3)
+    actions[0] = await Action.query().insert({
+      title: faker.lorem.words(2),
+      description: faker.lorem.words(10),
+      type: _.sample(['Retweet', 'Link', 'Share']),
+      config: { fake_number: faker.random.number() }
+    })
+    actions[1] = await Action.query().insert({
+      title: faker.lorem.words(2),
+      description: faker.lorem.words(10),
+      type: _.sample(['Retweet', 'Link', 'Share']),
+      config: { fake_number: faker.random.number() }
+    })
+    actions[2] = await Action.query().insert({
+      title: faker.lorem.words(2),
+      description: faker.lorem.words(10),
+      type: _.sample(['Retweet', 'Link', 'Share']),
+      config: { fake_number: faker.random.number() }
+    })
+
+    // Relate actions to base campaign
+    await campaign.$relatedQuery('actions').relate(actions)
+
+    // Create a user to work with
+    const user = await User.query().insert({
+      email: faker.internet.email(),
+      external_id: faker.random.number(10)
+    })
+
+    stubs.currentCampaign = campaign
+    stubs.currentUser = user
+    stubs.actions = actions
+  })
+
+  it('returns all actions for currentCampaign', async () => {
+    const context = { User: stubs.currentUser, Campaign: stubs.currentCampaign }
+    const userId = stubs.currentUser.id
+
+    const result = await Query.getUserActions(null, { userId }, context)
+
+    result.forEach((item, index) => {
+      expect(item.title).toEqual(stubs.actions[index].title)
+      expect(item.completed).toBeFalsy()
+    })
+  })
+
+  it('returns completed status for each action', async () => {
+    const context = { User: stubs.currentUser, Campaign: stubs.currentCampaign }
+    const userId = stubs.currentUser.id
+
+    // pretend a completed action using `actions[0].id`
+    await UserAction.query().insert({
+      actionId: stubs.actions[0].id,
+      campaignId: stubs.currentCampaign.id,
+      userId: stubs.currentUser.id,
+      completed: true
+    })
+
+    const result = await Query.getUserActions(null, { userId }, context)
+
+    expect(result[0].completed).toBeTruthy()
   })
 })

--- a/resolvers/index.js
+++ b/resolvers/index.js
@@ -44,25 +44,6 @@ const queryResolvers = {
     const campaignActions = result.campaigns[0].actions
 
     return campaignActions
-  },
-  /**
-   * Retrieve the records of UserActions for a given user and campaign
-   */
-  userActions: async (root, { userId, campaignId }) => {
-    // TODO: avoid the short-circuit and add conditionally "where" filter
-    if (campaignId) {
-      const result = await User.query()
-        .findById(userId)
-        .joinEager('userActions')
-        .where('campaignId', campaignId)
-
-      return result.userActions
-    }
-
-    const result = await User.query()
-      .findById(userId)
-      .joinEager('userActions')
-    return result.userActions
   }
 }
 

--- a/schema.js
+++ b/schema.js
@@ -69,7 +69,18 @@ const typeDefs = gql`
     currentUser: User!
     campaigns: [Campaign]
     userCampaignsActions(userId: ID!, campaignId: ID!): [Action]
-    getUserActions(userId: ID!): [UserAction]
+    getUserActions(userId: ID!): [GetUserActionsPayload]
+  }
+
+  type GetUserActionsPayload {
+    actionId: ID!
+    userActionId: ID
+    campaignId: ID!
+    title: String
+    description: String
+    type: String!
+    config: JSONObject
+    completed: Boolean!
   }
 
   type Mutation {

--- a/schema.js
+++ b/schema.js
@@ -69,7 +69,7 @@ const typeDefs = gql`
     currentUser: User!
     campaigns: [Campaign]
     userCampaignsActions(userId: ID!, campaignId: ID!): [Action]
-    userActions(userId: ID!, campaignId: ID): [UserAction]
+    getUserActions(userId: ID!): [UserAction]
   }
 
   type Mutation {


### PR DESCRIPTION
**What:**
replace old `userActions ` for `getUserActions` query within UserActions resolver in order to expose a resolver that can feed the needs for the `/actions` page

**Why:**
re #17 

**How:**
- Add resolver along side schema definition 103b312 61b74f2

![image](https://user-images.githubusercontent.com/1425162/69903446-993c2080-1399-11ea-9bed-e9405bc13f05.png)

**NOTE:** we still having issues to run the test in a deterministic way. Some times the test suite pass and some times it does not