### PR TITLE
Add new resolver to retrieve the amount of users joined into a campaign

### DIFF
--- a/migrations/20191126194405_add_data_column_user_campaigns.js
+++ b/migrations/20191126194405_add_data_column_user_campaigns.js
@@ -1,7 +1,9 @@
 exports.up = function (knex, Promise) {
-  return knex.schema.table('users_campaigns', function (t) {
-    t.jsonb('data').default({})
-  })
+  return knex.schema
+    .table('users_campaigns', function (t) {
+      t.jsonb('data').default({})
+    })
+    .raw("CREATE INDEX on ?? ((??#>>'{motive}'))", ['users_campaigns', 'data'])
 }
 
 exports.down = function (knex, Promise) {

--- a/models/UserCampaign.js
+++ b/models/UserCampaign.js
@@ -1,5 +1,4 @@
 const Model = require('./BaseModel')
-const { ref } = require('objection')
 
 class UserCampaign extends Model {
   static get tableName () {
@@ -8,16 +7,10 @@ class UserCampaign extends Model {
 
   static async getUserCountByMotive (motive) {
     const result = await UserCampaign.query()
-      // FIXME: this currently doesn't work since json_column not exists
-      .select([
-        'id',
-        ref('jsonColumn:data.motive')
-          .castText()
-          .as('motive')
-      ])
-      .where('motive', motive)
-      .count('id')
-    return Number(result[0].count)
+      .select(['id'])
+      .where('data', { motive })
+
+    return result.length
   }
 }
 

--- a/models/UserCampaign.js
+++ b/models/UserCampaign.js
@@ -6,12 +6,17 @@ class UserCampaign extends Model {
     return 'users_campaigns'
   }
 
-  static async getUserCountByMotive (motive) {
+  static async getUserCountByMotive () {
     const result = await UserCampaign.query()
-      .select(['id'])
-      .where(ref('data:motive').castText(), motive)
+      .select(
+        ref('users_campaigns.data:motive')
+          .castText()
+          .as('motive')
+      )
+      .groupBy('motive')
+      .count('id')
 
-    return result.length
+    return result
   }
 }
 

--- a/models/UserCampaign.js
+++ b/models/UserCampaign.js
@@ -1,4 +1,5 @@
 const Model = require('./BaseModel')
+const { ref } = require('objection')
 
 class UserCampaign extends Model {
   static get tableName () {
@@ -8,7 +9,7 @@ class UserCampaign extends Model {
   static async getUserCountByMotive (motive) {
     const result = await UserCampaign.query()
       .select(['id'])
-      .where('data', { motive })
+      .where(ref('data:motive').castText(), motive)
 
     return result.length
   }

--- a/models/UserCampaign.js
+++ b/models/UserCampaign.js
@@ -1,0 +1,26 @@
+const Model = require('./BaseModel')
+const { ref } = require('objection')
+
+class UserCampaign extends Model {
+  static get tableName () {
+    return 'users_campaigns'
+  }
+
+  static async getUserCountByMotive (motive) {
+    const result = await UserCampaign.query()
+      // FIXME: this currently doesn't work since json_column not exists
+      .select([
+        'id',
+        ref('jsonColumn:data.motive')
+          .castText()
+          .as('motive')
+      ])
+      .where('motive', motive)
+      .count('id')
+    return Number(result[0].count)
+  }
+}
+
+module.exports = {
+  UserCampaign
+}

--- a/models/__tests__/UserCampaign.spec.js
+++ b/models/__tests__/UserCampaign.spec.js
@@ -37,6 +37,7 @@ test('retrives the amount of users joined into a campaign for a given motive', a
 
   // Setup variables to make the final assertion
   const motive = 'already-on-strike'
+  const randomMotive = faker.random.word()
   const users = Array(3)
   users[0] = await User.query()
     .where('external_id', 1)
@@ -62,8 +63,19 @@ test('retrives the amount of users joined into a campaign for a given motive', a
 
   await users[2].$relatedQuery('campaigns').relate({
     ...campaign,
-    data: { motive: faker.random.word() }
+    data: { motive: randomMotive }
   })
 
-  await expect(UserCampaign.getUserCountByMotive(motive)).resolves.toEqual(2)
+  await expect(UserCampaign.getUserCountByMotive()).resolves.toEqual(
+    expect.arrayContaining([
+      {
+        motive,
+        count: '2'
+      },
+      {
+        motive: randomMotive,
+        count: '1'
+      }
+    ])
+  )
 })

--- a/models/__tests__/UserCampaign.spec.js
+++ b/models/__tests__/UserCampaign.spec.js
@@ -1,13 +1,22 @@
+const Model = require('../../lib/objection')
 const { UserCampaign } = require('../UserCampaign')
 const { User } = require('../User')
 const { Campaign } = require('../Campaign')
 const faker = require('faker')
 
-test('retrives the amount of users joined into a campaign for a given motive', async () => {
+beforeEach(async () => {
   // Make sure to clean the db before running any assertion
   await User.query().delete()
   await Campaign.query().delete()
+})
 
+afterAll(async () => {
+  await User.query().delete()
+  await Campaign.query().delete()
+  Model.knex().destroy()
+})
+
+test('retrives the amount of users joined into a campaign for a given motive', async () => {
   // Populate db with data that can be use to emulate the flow to test
   await Campaign.query().insert({
     slug: 'a-campaign',

--- a/models/__tests__/UserCampaign.spec.js
+++ b/models/__tests__/UserCampaign.spec.js
@@ -3,7 +3,7 @@ const { User } = require('../User')
 const { Campaign } = require('../Campaign')
 const faker = require('faker')
 
-test.skip('retrives the amount of users joined into a campaign for a given motive', async () => {
+test('retrives the amount of users joined into a campaign for a given motive', async () => {
   // Make sure to clean the db before running any assertion
   await User.query().delete()
   await Campaign.query().delete()

--- a/resolvers/UserCampaign.js
+++ b/resolvers/UserCampaign.js
@@ -1,0 +1,14 @@
+const { UserCampaign } = require('../models/UserCampaign')
+
+const Query = {
+  getUserCampaignsCountByMotive: async (root, { motive }, context) => {
+    return UserCampaign.getUserCountByMotive(motive)
+  }
+}
+
+const Mutation = {}
+
+module.exports = {
+  Query,
+  Mutation
+}

--- a/resolvers/index.js
+++ b/resolvers/index.js
@@ -4,6 +4,7 @@ const { Campaign } = require('../models/Campaign')
 const { User } = require('../models/User')
 const { UserAction } = require('../models/UserAction')
 const UserActions = require('../resolvers/UserActions')
+const UserCampaign = require('../resolvers/UserCampaign')
 const { setContext } = require('./context')
 const sentryWrapper = require('../lib/sentryWrapper')
 
@@ -83,8 +84,16 @@ const mutationResolvers = {
   }
 }
 
-const allQueryResolvers = _.merge(queryResolvers, UserActions.Query)
-const allMutationResolvers = _.merge(mutationResolvers, UserActions.Mutation)
+const allQueryResolvers = _.merge(
+  queryResolvers,
+  UserActions.Query,
+  UserCampaign.Query
+)
+const allMutationResolvers = _.merge(
+  mutationResolvers,
+  UserActions.Mutation,
+  UserCampaign.Mutation
+)
 
 const allQueryResolversWrapped = sentryWrapper(allQueryResolvers)
 const allMutationResolversWrapped = sentryWrapper(allMutationResolvers)

--- a/schema.js
+++ b/schema.js
@@ -70,6 +70,7 @@ const typeDefs = gql`
     campaigns: [Campaign]
     userCampaignsActions(userId: ID!, campaignId: ID!): [Action]
     getUserActions(userId: ID!): [GetUserActionsPayload]
+    getUserCampaignsCountByMotive(motive: String!): Int!
   }
 
   type GetUserActionsPayload {


### PR DESCRIPTION
**What:**
Add "getUserCampaignsCountByMotive" Query to allow client to know the amount of users joined into a campaign by specific motive

**Why:**
re https://github.com/debtcollective/student-debt-campaign/issues/19

**How:**
- Add a new Objectionjs model of `UserCampaign` to being able to interact with the `users_campaigns` table c0c64c2
- Use the JSONB query to get the count with motive 3433215
- Indexing the query for performance boost 3da7d00 [database column indexing structure](https://user-images.githubusercontent.com/1425162/70178113-f3abe880-16db-11ea-932c-66b50144faf5.png)
- Add new resolver to expose count query 3a25299

![image](https://user-images.githubusercontent.com/1425162/70222135-d3b30e00-1749-11ea-915b-2846cdc75a8e.png)
