### PR TITLE
Add detail views for actions

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,6 +4,14 @@
     {
       "type": "node",
       "request": "launch",
+      "name": "Launch Program",
+      "program": "${workspaceFolder}/index.js",
+      "skipFiles": ["<node_internals>/**"]
+    },
+
+    {
+      "type": "node",
+      "request": "launch",
       "name": "Jest All",
       "program": "${workspaceFolder}/node_modules/.bin/jest",
       "args": ["--runInBand"],
@@ -11,7 +19,7 @@
       "internalConsoleOptions": "neverOpen",
       "disableOptimisticBPs": true,
       "windows": {
-        "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+        "program": "${workspaceFolder}/node_modules/jest/bin/jest"
       }
     },
     {
@@ -19,16 +27,12 @@
       "request": "launch",
       "name": "Jest Current File",
       "program": "${workspaceFolder}/node_modules/.bin/jest",
-      "args": [
-        "${fileBasenameNoExtension}",
-        "--config",
-        "jest.config.js"
-      ],
+      "args": ["${fileBasenameNoExtension}", "--config", "jest.config.js"],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
       "disableOptimisticBPs": true,
       "windows": {
-        "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+        "program": "${workspaceFolder}/node_modules/jest/bin/jest"
       }
     }
   ]

--- a/migrations/20191003185952_create_actions.js
+++ b/migrations/20191003185952_create_actions.js
@@ -1,4 +1,4 @@
-exports.up = function(knex) {
+exports.up = function (knex) {
   return knex.schema.createTable('actions', table => {
     table.increments('id').primary()
     table
@@ -15,11 +15,11 @@ exports.up = function(knex) {
     // A way to categorize the action with UI proposes
     table.string('type')
     // A set of arguments needed to built the UI approperly
-    table.jsonb('config')
+    table.jsonb('config').default({})
     table.timestamps(false, true)
   })
 }
 
-exports.down = function(knex) {
+exports.down = function (knex) {
   return knex.schema.dropTableIfExists('actions')
 }

--- a/migrations/20191202152302_add_slug_to_actions.js
+++ b/migrations/20191202152302_add_slug_to_actions.js
@@ -1,0 +1,13 @@
+exports.up = function (knex) {
+  return knex.schema.table('actions', function (t) {
+    t.string('slug').notNull()
+    t.unique(['campaign_id', 'slug']) // slugs are unique in a campaign
+  })
+}
+
+exports.down = function (knex) {
+  return knex.schema.table('actions', function (t) {
+    t.dropUnique(['campaign_id', 'slug'])
+    t.dropColumn('slug')
+  })
+}

--- a/resolvers/UserActions.js
+++ b/resolvers/UserActions.js
@@ -58,7 +58,11 @@ const validationSchema = yup.object().shape({
       accountStatus: yup
         .mixed()
         .oneOf([...accountStatuses, unknown], 'Account status is required'),
-      beingHarrased: yup.string().required('You need to answer this question')
+      beingHarrased: yup.string().required('You need to answer this question'),
+      harrasmentDescription: yup.string().when('beingHarrased', {
+        is: 'true',
+        then: yup.string().required()
+      })
     })
   )
 })

--- a/resolvers/UserActions.js
+++ b/resolvers/UserActions.js
@@ -53,7 +53,7 @@ const validationSchema = yup.object().shape({
         .mixed()
         .oneOf([...studentDebtTypes, unknown], 'Student debt type is required'),
       amount: yup.number().required('Amount is required'),
-      interestRate: yup.number().required('Interest rate is required'),
+      interestRate: yup.string().required('Interest rate is required'),
       creditor: yup.string().required('Creditor is required'),
       accountStatus: yup
         .mixed()
@@ -114,7 +114,7 @@ const Query = {
 }
 
 const Mutation = {
-  createDataDuesAction: async (parent, args, context) => {
+  upsertDataDuesAction: async (parent, args, context) => {
     // get data from args
     const { data } = args
     const { User: user, Campaign: campaign } = context

--- a/resolvers/UserActions.js
+++ b/resolvers/UserActions.js
@@ -93,6 +93,23 @@ const Query = {
     })
 
     return _.sortBy(result, 'actionId')
+  },
+  userAction: async (root, { slug }, context) => {
+    const { Campaign: campaign, User: user } = context
+
+    const action = await campaign
+      .$relatedQuery('actions')
+      .findOne({ slug, campaignId: campaign.id })
+
+    if (!action) {
+      return
+    }
+
+    const userAction = await user
+      .$relatedQuery('userActions')
+      .findOne({ actionId: action.id })
+
+    return userAction
   }
 }
 

--- a/resolvers/__tests__/UserActions.spec.js
+++ b/resolvers/__tests__/UserActions.spec.js
@@ -116,14 +116,17 @@ describe('UserActions resolvers', () => {
     })
 
     describe('with existing record', () => {
-      it('returns existing record', async () => {
+      it('updates existing record', async () => {
         // insert record
         await UserAction.query().insert({
           userId: user.id,
           campaignId: campaign.id,
           actionId: action.id,
           completed: true,
-          data: { fullName: 'Orlando Del Aguila' }
+          data: {
+            fullName: 'Orlando Del Aguila',
+            email: 'orlando@debtcollective.org'
+          }
         })
 
         const data = {
@@ -131,12 +134,14 @@ describe('UserActions resolvers', () => {
             {
               accountStatus: 'Late on payments',
               amount: 5000,
-              beingHarrased: '',
-              creditor: '',
-              debtType: '',
+              beingHarrased: 'false',
+              creditor: 'Sallie Mae',
+              debtType: 'Student debt',
+              studentDebtType: 'Parent PLUS',
               interestRate: 4.53
             }
           ],
+          streetAddress: '400 Maryland Avenue, SW. Washington, DC 20202',
           email: 'betsy.devos@ed.gov',
           fullName: 'Betsy DeVos',
           phoneNumber: '(202) 401-3000'
@@ -151,9 +156,7 @@ describe('UserActions resolvers', () => {
         expect(payload).not.toBeNull()
         expect(payload.userAction).not.toBeNull()
         expect(payload.errors).toBeUndefined()
-        expect(payload.userAction.data).toEqual({
-          fullName: 'Orlando Del Aguila'
-        })
+        expect(payload.userAction.data).toEqual(data)
       })
     })
   })

--- a/resolvers/__tests__/UserActions.spec.js
+++ b/resolvers/__tests__/UserActions.spec.js
@@ -134,11 +134,12 @@ describe('UserActions resolvers', () => {
             {
               accountStatus: 'Late on payments',
               amount: 5000,
-              beingHarrased: 'false',
+              beingHarrased: 'true',
               creditor: 'Sallie Mae',
               debtType: 'Student debt',
               studentDebtType: 'Parent PLUS',
-              interestRate: '4.53'
+              interestRate: '4.53',
+              harrasmentDescription: "I'm being harrased"
             }
           ],
           streetAddress: '400 Maryland Avenue, SW. Washington, DC 20202',

--- a/resolvers/__tests__/UserActions.spec.js
+++ b/resolvers/__tests__/UserActions.spec.js
@@ -10,7 +10,7 @@ const _ = require('lodash')
 afterAll(() => Model.knex().destroy())
 
 describe('UserActions resolvers', () => {
-  describe('createDataDues', () => {
+  describe('upsertDataDuesAction', () => {
     let user
     let campaign
     let context
@@ -54,7 +54,7 @@ describe('UserActions resolvers', () => {
               beingHarrased: 'false',
               creditor: 'Sallie Mae',
               debtType: 'Student debt',
-              interestRate: 4.53,
+              interestRate: '4.53',
               studentDebtType: 'Subsidized Stafford'
             }
           ],
@@ -63,7 +63,7 @@ describe('UserActions resolvers', () => {
           phoneNumber: '(202) 401-3000'
         }
 
-        const payload = await Mutation.createDataDuesAction(
+        const payload = await Mutation.upsertDataDuesAction(
           null,
           { data },
           context
@@ -87,7 +87,7 @@ describe('UserActions resolvers', () => {
               beingHarrased: '',
               creditor: '',
               debtType: '',
-              interestRate: 4.53
+              interestRate: '4.53'
             }
           ],
           email: 'betsy.devos@ed.gov',
@@ -95,7 +95,7 @@ describe('UserActions resolvers', () => {
           phoneNumber: '(202) 401-3000'
         }
 
-        const payload = await Mutation.createDataDuesAction(
+        const payload = await Mutation.upsertDataDuesAction(
           null,
           { data },
           context
@@ -138,7 +138,7 @@ describe('UserActions resolvers', () => {
               creditor: 'Sallie Mae',
               debtType: 'Student debt',
               studentDebtType: 'Parent PLUS',
-              interestRate: 4.53
+              interestRate: '4.53'
             }
           ],
           streetAddress: '400 Maryland Avenue, SW. Washington, DC 20202',
@@ -147,7 +147,7 @@ describe('UserActions resolvers', () => {
           phoneNumber: '(202) 401-3000'
         }
 
-        const payload = await Mutation.createDataDuesAction(
+        const payload = await Mutation.upsertDataDuesAction(
           null,
           { data },
           context

--- a/resolvers/index.js
+++ b/resolvers/index.js
@@ -83,14 +83,16 @@ const mutationResolvers = {
   }
 }
 
-const allQueryResolvers = _.merge(queryResolvers, UserActions.Query)
-const allMutationResolvers = _.merge(mutationResolvers, UserActions.Mutation)
+let allQueryResolvers = _.merge(queryResolvers, UserActions.Query)
+let allMutationResolvers = _.merge(mutationResolvers, UserActions.Mutation)
 
-const allQueryResolversWrapped = sentryWrapper(allQueryResolvers)
-const allMutationResolversWrapped = sentryWrapper(allMutationResolvers)
+if (process.env.SENTRY_DSN) {
+  allQueryResolvers = sentryWrapper(allQueryResolvers)
+  allMutationResolvers = sentryWrapper(allMutationResolvers)
+}
 
 module.exports = {
   setContext,
-  queryResolvers: allQueryResolversWrapped,
-  mutationResolvers: allMutationResolversWrapped
+  queryResolvers: allQueryResolvers,
+  mutationResolvers: allMutationResolvers
 }

--- a/schema.js
+++ b/schema.js
@@ -60,6 +60,8 @@ const typeDefs = gql`
     completed: Boolean!
     "common data related to the action"
     action: Action
+    " JSONB data"
+    data: JSONObject
   }
 
   type Ok {
@@ -72,6 +74,7 @@ const typeDefs = gql`
     campaigns: [Campaign]
     userCampaignsActions(userId: ID!, campaignId: ID!): [Action]
     getUserActions(userId: ID!): [GetUserActionsPayload]
+    userAction(slug: String!): UserAction
   }
 
   type GetUserActionsPayload {

--- a/schema.js
+++ b/schema.js
@@ -30,6 +30,8 @@ const typeDefs = gql`
     campaignId: ID!
     "title of the action"
     title: String!
+    "action slug"
+    slug: String!
     "description of the action"
     description: String!
     "define the type of UI to render"
@@ -81,6 +83,7 @@ const typeDefs = gql`
     type: String!
     config: JSONObject
     completed: Boolean!
+    slug: String!
   }
 
   type Mutation {

--- a/schema.js
+++ b/schema.js
@@ -92,10 +92,10 @@ const typeDefs = gql`
   type Mutation {
     userActionUpdate(userActionId: ID!, completed: Boolean): UserAction!
     addUserToCampaign(motive: String!): Ok!
-    createDataDuesAction(data: JSONObject): CreateDataDuesActionPayload!
+    upsertDataDuesAction(data: JSONObject): UpsertDataDuesActionPayload!
   }
 
-  type CreateDataDuesActionPayload {
+  type UpsertDataDuesActionPayload {
     errors: JSONObject
     userAction: UserAction
   }

--- a/schema.js
+++ b/schema.js
@@ -93,6 +93,11 @@ const typeDefs = gql`
     userActionUpdate(userActionId: ID!, completed: Boolean): UserAction!
     addUserToCampaign(motive: String!): Ok!
     upsertDataDuesAction(data: JSONObject): UpsertDataDuesActionPayload!
+    upsertUserAction(
+      slug: String!
+      completed: Boolean
+      data: JSONObject
+    ): UserAction!
   }
 
   type UpsertDataDuesActionPayload {

--- a/seeds/002_actions.js
+++ b/seeds/002_actions.js
@@ -3,10 +3,11 @@ exports.seed = function (knex) {
     {
       id: 1,
       campaign_id: 1,
-      title: 'Data Dues',
+      title: 'Add your debt data',
       description:
         'Data dues action where we request user about their debt data',
       type: 'data-dues',
+      slug: 'data-dues',
       config: {}
     }
   ])

--- a/seeds/002_actions.js
+++ b/seeds/002_actions.js
@@ -1,14 +1,47 @@
 exports.seed = function (knex) {
   return knex('actions').insert([
     {
-      id: 1,
       campaign_id: 1,
       title: 'Add your debt data',
       description:
         'Data dues action where we request user about their debt data',
       type: 'data-dues',
-      slug: 'data-dues',
-      config: {}
+      slug: 'data-dues'
+    },
+    {
+      campaign_id: 1,
+      title: 'Contact Your Rep',
+      description: 'Contact Your Rep using this form',
+      type: 'action',
+      slug: 'contact-your-rep'
+    },
+    {
+      campaign_id: 1,
+      title: 'Start a Campus Group',
+      description: 'Start a Campus Group',
+      type: 'link',
+      slug: 'start-a-campus-group'
+    },
+    {
+      campaign_id: 1,
+      title: 'Join A Direct Action Team',
+      description: 'Join A Direct Action Team',
+      type: 'link',
+      slug: 'join-a-direct-action-team'
+    },
+    {
+      campaign_id: 1,
+      title: 'Join Our Social Media Team',
+      description: 'Join Our Social Media Team',
+      type: 'link',
+      slug: 'join-our-social-media-team'
+    },
+    {
+      campaign_id: 1,
+      title: 'Contribute Your Ideas',
+      description: 'Contribute Your Ideas',
+      type: 'link',
+      slug: 'contribute-your-ideas'
     }
   ])
 }


### PR DESCRIPTION
**What:** Add detail views for actions

**Why:** Related to https://github.com/debtcollective/student-debt-campaign/pull/71

**How:**

- Add seeds for the student debt campaign
- Add sentry monitoring only if DNS is present
- Add userAction resolver
- Fix missing field in data dues schema 
