### PR TITLE
ci: add --runInBand to jest for test to serially

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lint": "eslint '**/*.js' --fix",
     "test": "jest",
     "test:watch": "jest --watch",
-    "test:ci": "jest --coverage"
+    "test:ci": "jest --coverage --runInBand"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
**What:** add --runInBand to jest for test to serially

**Why:** This fixes our tests failing when being executed in parallel. We need to improve our tests to not need this option

**How:**

- add `--runInBand` to `yarn test:ci` command