### PR TITLE
feat: allow multiple CORS origins

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,4 +1,4 @@
-CORS_ORIGIN=http://campaign.lvh.me:8000
+CORS_ORIGIN=http://campaign.lvh.me:8000,http://strike.lvh.me:8000
 SSO_JWT_SECRET=jwt-secret
 SSO_COOKIE_NAME=tdc_auth_token
 DEV_HOST=campaign-api.lvh.me

--- a/index.js
+++ b/index.js
@@ -62,8 +62,10 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN
 })
 
+const originSafelist = (process.env.CORS_ORIGIN || '').split(',')
+
 const corsOptions = {
-  origin: process.env.CORS_ORIGIN,
+  origin: originSafelist,
   credentials: true
 }
 


### PR DESCRIPTION
**What:** allow multiple CORS origins

**Why:** We want to host the site in campaign.debtcollective.org and strike.debtcollective.org, this will also allow us to add testing URLs in the future.

**How:**

- Pass an array of origins to `corsOptions` instead of a string
