### PR TITLE
dev: sync data dues schema with frontend

### DIFF
--- a/resolvers/UserActions.js
+++ b/resolvers/UserActions.js
@@ -15,16 +15,11 @@ const debtTypes = [
   'Credit card debt',
   'Other'
 ]
-const studentDebtTypes = [
-  'Subsidized Stafford',
-  'Unsubsidized Stafford',
-  'Parent PLUS',
-  'Private Student loans'
-]
+const studentDebtTypes = ['Federal loan', 'Parent Plus loan', 'Private loan']
 const accountStatuses = [
   'In repayment',
   'Late on payments',
-  'Stopped payments',
+  'Forbearance/Deferment',
   'Sent to collections'
 ]
 const phoneRegExp = /^(\([0-9]{3}\) |[0-9]{3}-)[0-9]{3}-[0-9]{4}$/
@@ -52,7 +47,7 @@ const validationSchema = yup.object().shape({
         .oneOf([...studentDebtTypes, unknown], 'Student debt type is required'),
       amount: yup.number().required('Amount is required'),
       interestRate: yup.string().required('Interest rate is required'),
-      creditor: yup.string().required('Creditor is required'),
+      creditor: yup.string().required('This field is required'),
       accountStatus: yup
         .mixed()
         .oneOf([...accountStatuses, unknown], 'Account status is required'),

--- a/resolvers/__tests__/UserActions.spec.js
+++ b/resolvers/__tests__/UserActions.spec.js
@@ -56,7 +56,7 @@ describe('UserActions resolvers', () => {
               creditor: 'Sallie Mae',
               debtType: 'Student debt',
               interestRate: '4.53',
-              studentDebtType: 'Subsidized Stafford'
+              studentDebtType: 'Federal loan'
             }
           ],
           email: 'betsy.devos@ed.gov',
@@ -138,7 +138,7 @@ describe('UserActions resolvers', () => {
               beingHarrased: 'true',
               creditor: 'Sallie Mae',
               debtType: 'Student debt',
-              studentDebtType: 'Parent PLUS',
+              studentDebtType: 'Parent Plus loan',
               interestRate: '4.53',
               harrasmentDescription: "I'm being harrased"
             }

--- a/resolvers/__tests__/UserActions.spec.js
+++ b/resolvers/__tests__/UserActions.spec.js
@@ -107,7 +107,7 @@ describe('UserActions resolvers', () => {
         expect(payload.errors).not.toBeNull()
         expect(payload.errors).toEqual([
           { field: 'debts[0].debtType', message: 'Debt type is required' },
-          { field: 'debts[0].creditor', message: 'Creditor is required' },
+          { field: 'debts[0].creditor', message: 'This field is required' },
           {
             field: 'debts[0].beingHarrased',
             message: 'You need to answer this question'


### PR DESCRIPTION
**What:** sync data dues schema with frontend

**Why:** Related to https://github.com/debtcollective/student-debt-campaign/pull/92

**How:**

- Update data dues yup validation schema