### PR TITLE
fix(current-user): guard against null when checking for user

### DIFF
--- a/models/stubs/index.js
+++ b/models/stubs/index.js
@@ -8,20 +8,22 @@ module.exports = {
   }),
   createCampaign: fixedData => ({
     name: faker.lorem.words(2),
-    slug: faker.lorem
-      .words(2)
-      .toLowerCase()
-      .split(' ')
-      .join('-'),
-    ...fixedData
+    slug: faker.random.uuid()
   }),
   createActions: (fixedData, amount = 2) => {
-    return Array(amount).fill({
-      title: faker.lorem.words(2),
-      description: faker.lorem.words(10),
-      type: 'Retweet',
-      config: { tweet_id: faker.random.number() },
-      ...fixedData
-    })
+    const array = []
+
+    for (let i = 0; i < amount; i = i + 1) {
+      array.push({
+        title: faker.lorem.words(2),
+        description: faker.lorem.words(10),
+        slug: faker.random.uuid(),
+        type: 'Retweet',
+        config: { tweet_id: faker.random.number() },
+        ...fixedData
+      })
+    }
+
+    return array
   }
 }

--- a/resolvers/__tests__/UserActions.spec.js
+++ b/resolvers/__tests__/UserActions.spec.js
@@ -7,7 +7,13 @@ const { Mutation, Query } = require('../UserActions')
 const faker = require('faker')
 const _ = require('lodash')
 
-afterAll(() => Model.knex().destroy())
+afterAll(async () => {
+  await UserAction.query().delete()
+  await Action.query().delete()
+  await User.query().delete()
+  await Campaign.query().delete()
+  Model.knex().destroy()
+})
 
 describe('UserActions resolvers', () => {
   describe('upsertDataDuesAction', () => {

--- a/resolvers/__tests__/index.spec.js
+++ b/resolvers/__tests__/index.spec.js
@@ -70,7 +70,7 @@ afterAll(async () => {
   Model.knex().destroy()
 })
 
-describe.skip('Query resolvers', () => {
+describe('Query resolvers', () => {
   it('returns all campaigns with #campaigns method', async () => {
     const campaigns = await queryResolvers.campaigns()
     const campaignIds = _.map(campaigns, 'id').sort()
@@ -94,28 +94,6 @@ describe.skip('Query resolvers', () => {
     expect(actionsIds).toEqual(targetedCampaignActionsIds)
   })
 
-  it("returns the 'UserActions' for a given user", async () => {
-    const userActions = await queryResolvers.userActions(null, {
-      userId: stubs.user.id
-    })
-    const userActionsIds = _.map(userActions, 'id').sort()
-    const stubUserActionsIds = _.map(stubs.userActions, 'id').sort()
-
-    expect(userActionsIds).toEqual(stubUserActionsIds)
-  })
-
-  it("returns the 'UserActions' for a given user filtered by campaignId", async () => {
-    const userActions = await queryResolvers.userActions(null, {
-      userId: stubs.user.id,
-      campaignId: stubs.campaigns[2].id
-    })
-    const userActionsIds = _.map(userActions, 'id').sort()
-    const stubUserActionsIds = [stubs.userActions[1].id]
-
-    expect(userActions).toHaveLength(1)
-    expect(userActionsIds).toEqual(stubUserActionsIds)
-  })
-
   it("returns the injected 'User' as a context with #currentUser", async () => {
     const context = {
       User: createUser({ external_id: faker.random.number() })
@@ -137,7 +115,7 @@ describe.skip('Query resolvers', () => {
   })
 })
 
-describe.skip('Mutation resolvers', () => {
+describe('Mutation resolvers', () => {
   it('allows to update the completed value with #userActionUpdate', async () => {
     const actionId = stubs.campaigns[0].actions[1].id
     const campaignId = stubs.campaigns[0].id

--- a/resolvers/index.js
+++ b/resolvers/index.js
@@ -19,11 +19,13 @@ const queryResolvers = {
    * Retrive user using Cookies
    */
   currentUser: async (root, args, context) => {
-    if (!context.User.external_id) {
+    const { User: user } = context
+
+    if (!user || !user.external_id) {
       throw new AuthenticationError('No user logged in')
     }
 
-    return context.User
+    return user
   },
   /**
    * Retrieve all the campaigns alongside its actions


### PR DESCRIPTION
**What:**
guard against null when checking for user

**Why:**
Fix #22 

**How:**

- Make sure we have a user before checking for `external_id`