### PR TITLE
fix: parse string as boolean values

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ const resolvers = {
   },
   // Allow to append action data into the UserAction request
   UserAction: {
-    action: async userAction => {
+    action: async (userAction) => {
       const { actionId } = userAction
       const result = await Action.query().findById(actionId)
       return result
@@ -43,10 +43,8 @@ const resolvers = {
   },
   // Allow to append campaigns data into User request
   User: {
-    campaigns: async user => {
-      const result = await User.query()
-        .findById(user.id)
-        .joinEager('campaigns')
+    campaigns: async (user) => {
+      const result = await User.query().findById(user.id).joinEager('campaigns')
 
       if (result) {
         return result.campaigns
@@ -73,8 +71,8 @@ const server = new ApolloServer({
   cors: corsOptions,
   typeDefs,
   resolvers,
-  introspection: process.env.INTROSPECTION,
-  playground: process.env.PLAYGROUND,
+  introspection: process.env.INTROSPECTION === 'true',
+  playground: process.env.PLAYGROUND === 'true',
   context: setContext
 })
 

--- a/resolvers/context.js
+++ b/resolvers/context.js
@@ -6,8 +6,11 @@ const { Campaign } = require('../models/Campaign')
 const setContext = async ({ req }) => {
   let user = null
 
+  const campaign = await Campaign.query().eager('actions').first()
+
   try {
     const authCookieName = process.env.SSO_COOKIE_NAME
+
     const cookies = cookie.parse(req.headers.cookie)
     const authToken = cookies[authCookieName]
     const payload = jwt.verify(authToken, process.env.SSO_JWT_SECRET)
@@ -17,10 +20,6 @@ const setContext = async ({ req }) => {
     // eslint-disable-next-line no-console
     console.error(err)
   }
-
-  const campaign = await Campaign.query()
-    .eager('actions')
-    .first()
 
   return { User: user, Campaign: campaign }
 }


### PR DESCRIPTION
**What:** Parse string as boolean values in environment variables

**Why:** To allow us disable the playground in production

**How:**

- assert string to "true" to cast it to boolean
