### PR TITLE
feat: add volunteers action to seeds

### DIFF
--- a/seeds/002_actions.js
+++ b/seeds/002_actions.js
@@ -62,6 +62,16 @@ exports.seed = function (knex) {
         href:
           'https://community.debtcollective.org/t/contribute-your-ideas-to-the-college-for-all-campaign/3468'
       }
+    },
+    {
+      campaign_id: 1,
+      title: 'Volunteer with The Debt Collective',
+      description: 'Volunteer with The Debt Collective',
+      type: 'link',
+      slug: 'volunteer-with-the-debt-collective',
+      config: {
+        href: 'https://volunteer.debtcollective.org'
+      }
     }
   ])
 }


### PR DESCRIPTION
**What:** Add volunteers action to seeds.

Seeds are a one time run task so this will be added to the database manually.

![image](https://user-images.githubusercontent.com/849872/79286691-ffc46580-7e86-11ea-874f-02906cdc7a9c.png)

**Why:** Related to https://app.asana.com/0/1159164196409129/1170547450974121

**How:**

- Add volunteers action to seeds
