### PR TITLE
refactor: remove async/await from addTagsToContact method

### DIFF
--- a/lib/__tests__/mailchimp.spec.js
+++ b/lib/__tests__/mailchimp.spec.js
@@ -7,8 +7,10 @@ describe('mailchimp', () => {
   describe('addTagsToContact', () => {
     afterAll(() => jest.clearAllMocks())
 
-    it('throws error if list_id or email are not passed', async () => {
-      await expect(mailchimp.addTagsToContact()).rejects.toThrow(Error)
+    it('throws error if list_id or email are not passed', () => {
+      expect(() => {
+        mailchimp.addTagsToContact()
+      }).toThrow(Error)
     })
 
     it('updates tags for a contact if params are passed correctly', async () => {
@@ -20,11 +22,12 @@ describe('mailchimp', () => {
       const subscriber_hash = mailchimp._subscriberHash(params.email)
 
       axios.post.mockImplementationOnce(() =>
-        Promise.resolve({ data: {}, status: 204 })
+        Promise.resolve({ data: { ok: true }, status: 204 })
       )
 
-      await mailchimp.addTagsToContact(params)
+      const data = await mailchimp.addTagsToContact(params)
 
+      expect(data.ok).toBe(true)
       expect(axios.post).toHaveBeenCalledWith(
         `${mailchimp._url}/lists/${params.list_id}/members/${subscriber_hash}/tags`,
         { tags: params.tags },

--- a/lib/mailchimp.js
+++ b/lib/mailchimp.js
@@ -3,7 +3,7 @@ const Sentry = require('@sentry/node')
 const crypto = require('crypto')
 
 const mailchimp = {
-  addTagsToContact: async (args = {}) => {
+  addTagsToContact: (args = {}) => {
     const { list_id, email } = args
 
     if (!list_id || !email) {
@@ -12,28 +12,20 @@ const mailchimp = {
 
     const { tags = [] } = args
     const subscriber_hash = mailchimp._subscriberHash(email)
-    const requestBody = {
-      tags
+    const requestBody = { tags }
+    const url = `${mailchimp._url}/lists/${list_id}/members/${subscriber_hash}/tags`
+    const requestHeaders = {
+      auth: {
+        username: 'campaignApi',
+        password: process.env.MAILCHIMP_API_KEY
+      },
+      headers: { 'content-type': 'application/json' }
     }
 
-    try {
-      const response = await axios.post(
-        `${mailchimp._url}/lists/${list_id}/members/${subscriber_hash}/tags`,
-        requestBody,
-        {
-          auth: {
-            username: 'campaignApi',
-            password: process.env.MAILCHIMP_API_KEY
-          },
-          headers: { 'content-type': 'application/json' }
-        }
-      )
-      const data = response.data
-
-      return data
-    } catch (e) {
-      Sentry.captureException(e)
-    }
+    return axios
+      .post(url, requestBody, requestHeaders)
+      .then(response => response.data)
+      .catch(e => Sentry.captureException(e))
   },
   _url: 'https://us20.api.mailchimp.com/3.0',
   _subscriberHash: (email = '') =>


### PR DESCRIPTION
**What:** remove async/await from addTagsToContact method

**Why:** we shouldn't wait for MailChimp to respond to add a user to strike, this change effectively makes this.

**How:**
- Remove await from MailChimp call.